### PR TITLE
Match against non case-sensitive headers

### DIFF
--- a/shakedown.sh
+++ b/shakedown.sh
@@ -134,7 +134,7 @@ header_contains() {
 }
 
 _get_header() {
-  grep -F "${1}" "${RESPONSE_HEADERS}" | tr -d '\r'
+  grep -i -F "${1}" "${RESPONSE_HEADERS}" | tr -d '\r'
 }
 
 # debug


### PR DESCRIPTION
Thanks for the library, I have used it many times and it's such a useful tool!

We are using to run some smoke tests against our local & live deployment, but the live deployment is behind a content provider (cloudflare) which lower-cases the headers, so they pass locally but not in production.

As per https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html headers should not be case-sensitive, so I thought it would make sense to match against non case-sensitive version when pulling the value from it.

Thank you